### PR TITLE
Adds config to allow for shorter github urls

### DIFF
--- a/config/git/gitconfig
+++ b/config/git/gitconfig
@@ -19,3 +19,7 @@
 
 [credential]
 	helper = store --file=/secrets/gitcredentials
+
+[url "https://github.com/"]
+	insteadOf = gh:
+


### PR DESCRIPTION
For example, we can now use:
`git clone gh:JosephSalisbury/dev-workspace-container`
to clone this repo, which is pretty nifty.