### PR TITLE
Adds test that keys are present before importing

### DIFF
--- a/config/bash/bashrc
+++ b/config/bash/bashrc
@@ -18,9 +18,11 @@ if [ ! -f /secrets/public-gpg ]; then
     echo "warning - public gpg key not found"
 fi
 
-if ! gpg --list-keys | grep -q 'salisbury.joseph@gmail.com'; then
-    gpg --import /secrets/private-gpg
-    gpg --import /secrets/public-gpg
+if [ -f /secrets/private-gpg ] && [ -f /secrets/public-gpg ] ; then
+    if ! gpg --list-keys | grep -q 'salisbury.joseph@gmail.com' ; then
+        gpg --import /secrets/private-gpg
+        gpg --import /secrets/public-gpg
+    fi
 fi
 
 # Set the terminal size - this can be an issue when running as a Kubernetes pod.


### PR DESCRIPTION
Fixes https://github.com/JosephSalisbury/dev-workspace-container/issues/46

If the gpg keys aren't present, there's no point importing them,
so this changeset adds a check for that.